### PR TITLE
[chore] rename package imports and go module to catalogd

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/apiserver-runtime/pkg/builder"
 
 	// +kubebuilder:scaffold:resource-imports
-	corev1beta1 "github.com/anik120/rukpak-packageserver/pkg/apis/core/v1beta1"
+	corev1beta1 "github.com/anik120/catalogd/pkg/apis/core/v1beta1"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/anik120/rukpak-packageserver
+module github.com/anik120/catalogd
 
 go 1.19
 

--- a/main.go
+++ b/main.go
@@ -31,9 +31,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	"github.com/anik120/rukpak-packageserver/pkg/apis/core/v1beta1"
-	corecontrollers "github.com/anik120/rukpak-packageserver/pkg/controllers/core"
-	"github.com/anik120/rukpak-packageserver/pkg/profile"
+	"github.com/anik120/catalogd/pkg/apis/core/v1beta1"
+	corecontrollers "github.com/anik120/catalogd/pkg/controllers/core"
+	"github.com/anik120/catalogd/pkg/profile"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/pkg/controllers/core/bundlemetadata_controller.go
+++ b/pkg/controllers/core/bundlemetadata_controller.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	corev1beta1 "github.com/anik120/rukpak-packageserver/pkg/apis/core/v1beta1"
+	corev1beta1 "github.com/anik120/catalogd/pkg/apis/core/v1beta1"
 )
 
 // BundleMetadataReconciler reconciles a Package object

--- a/pkg/controllers/core/catalogsource_controller.go
+++ b/pkg/controllers/core/catalogsource_controller.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	corev1beta1 "github.com/anik120/rukpak-packageserver/pkg/apis/core/v1beta1"
+	corev1beta1 "github.com/anik120/catalogd/pkg/apis/core/v1beta1"
 )
 
 // CatalogSourceReconciler reconciles a CatalogSource object

--- a/pkg/controllers/core/package_controller.go
+++ b/pkg/controllers/core/package_controller.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	corev1beta1 "github.com/anik120/rukpak-packageserver/pkg/apis/core/v1beta1"
+	corev1beta1 "github.com/anik120/catalogd/pkg/apis/core/v1beta1"
 )
 
 // PackageReconciler reconciles a Package object


### PR DESCRIPTION
This commit renames the go module and package imports to catalogd instead of rukpak-packgeserver.

To make it easier to work with go workspaces :)