### PR TITLE
Add owner references in CatalogSource reconciliation logic

### DIFF
--- a/pkg/controllers/core/catalogsource_controller.go
+++ b/pkg/controllers/core/catalogsource_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	corev1beta1 "github.com/anik120/catalogd/pkg/apis/core/v1beta1"
@@ -140,7 +141,7 @@ func (r *CatalogSourceReconciler) buildBundleMetadata(ctx context.Context, declC
 			})
 		}
 
-		ctrl.SetControllerReference(&catalogSource, &bundleMeta, r.Scheme)
+		ctrlutil.SetOwnerReference(&catalogSource, &bundleMeta, r.Scheme)
 
 		if err := r.Client.Create(ctx, &bundleMeta); err != nil {
 			return fmt.Errorf("creating bundlemetadata %q: %w", bundleMeta.Name, err)
@@ -187,7 +188,7 @@ func (r *CatalogSourceReconciler) buildPackages(ctx context.Context, declCfg *de
 			}
 		}
 
-		ctrl.SetControllerReference(&catalogSource, &pack, r.Scheme)
+		ctrlutil.SetOwnerReference(&catalogSource, &pack, r.Scheme)
 
 		if err := r.Client.Create(ctx, &pack); err != nil {
 			return fmt.Errorf("creating package %q: %w", pack.Name, err)
@@ -199,7 +200,7 @@ func (r *CatalogSourceReconciler) buildPackages(ctx context.Context, declCfg *de
 func (r *CatalogSourceReconciler) createUnpackJob(ctx context.Context, cs corev1beta1.CatalogSource) error {
 	job := r.unpackJob(cs)
 
-	ctrl.SetControllerReference(&cs, job, r.Scheme)
+	ctrlutil.SetOwnerReference(&cs, job, r.Scheme)
 
 	if err := r.Client.Create(ctx, job); err != nil {
 		return fmt.Errorf("creating unpackJob: %w", err)

--- a/pkg/controllers/core/catalogsource_controller.go
+++ b/pkg/controllers/core/catalogsource_controller.go
@@ -140,6 +140,8 @@ func (r *CatalogSourceReconciler) buildBundleMetadata(ctx context.Context, declC
 			})
 		}
 
+		ctrl.SetControllerReference(&catalogSource, &bundleMeta, r.Scheme)
+
 		if err := r.Client.Create(ctx, &bundleMeta); err != nil {
 			return fmt.Errorf("creating bundlemetadata %q: %w", bundleMeta.Name, err)
 		}
@@ -185,6 +187,8 @@ func (r *CatalogSourceReconciler) buildPackages(ctx context.Context, declCfg *de
 			}
 		}
 
+		ctrl.SetControllerReference(&catalogSource, &pack, r.Scheme)
+
 		if err := r.Client.Create(ctx, &pack); err != nil {
 			return fmt.Errorf("creating package %q: %w", pack.Name, err)
 		}
@@ -194,6 +198,8 @@ func (r *CatalogSourceReconciler) buildPackages(ctx context.Context, declCfg *de
 
 func (r *CatalogSourceReconciler) createUnpackJob(ctx context.Context, cs corev1beta1.CatalogSource) error {
 	job := r.unpackJob(cs)
+
+	ctrl.SetControllerReference(&cs, job, r.Scheme)
 
 	if err := r.Client.Create(ctx, job); err != nil {
 		return fmt.Errorf("creating unpackJob: %w", err)


### PR DESCRIPTION
**Description**
For all resources created as a result of reconciling a `CatalogSource` CR, add owner references. This includes:
- All `Package` resources
- All `BundleMetadata` resources
- Unpack `Job`s

**Motivation**
- When deleting a `CatalogSource` CR, Kubernetes garbage collection automatically cleans up child resources
- fixes #7 